### PR TITLE
Don't crash on xml parser errors or malformed gpx files

### DIFF
--- a/lib/gpx-parse.js
+++ b/lib/gpx-parse.js
@@ -146,17 +146,23 @@ exports.parseGpx = function(gpxString, callback) {
 			return;
 		}
 
-		version = data.gpx.$.version;
-		if (version === "1.0") {
-			gpxResult = _ParseV10(data.gpx);
-		} else if (version === "1.1") {
-			gpxResult = _ParseV11(data.gpx);
-		} else {
-			callback(new Error("version not supported"), null);
-			return;
-		}
+		try {
+    		if (!data.hasOwnProperty('gpx')||!data.gpx.hasOwnProperty('$'))
+    			return callback(new Error("version not specified"), null);
 
-		callback(null, gpxResult);
+    		version = data.gpx.$.version;
+    		if (version === "1.0") {
+    			gpxResult = _ParseV10(data.gpx);
+    		} else if (version === "1.1") {
+    			gpxResult = _ParseV11(data.gpx);
+    		} else {
+    			callback(new Error("version not supported"), null);
+    			return;
+    		}
+            callback(null, gpxResult);
+        } catch (error) {
+            return callback(error);
+        }
 	});
 };
 


### PR DESCRIPTION
Had some problems with my node server crashing when users uploaded incompatible gpx-files. This will fix it.
