### PR TITLE
Add rest of Waypoint schema elements + tests

### DIFF
--- a/lib/gpx-parse.js
+++ b/lib/gpx-parse.js
@@ -28,7 +28,10 @@ var _getWayPoints = function(gpxWaypoints) {
 	var waypoints = [];
 	if (gpxWaypoints && gpxWaypoints.length) {
 		gpxWaypoints.forEach(function(wayPoint) {
-      var point = new GpxWaypoint(wayPoint.$.lat, wayPoint.$.lon, getFloat(wayPoint.ele), wayPoint.time, null, null, getString(wayPoint.name), null, getString(wayPoint.desc));
+      var point = new GpxWaypoint(wayPoint.$.lat, wayPoint.$.lon, getFloat(wayPoint.ele), wayPoint.time, getString(wayPoint.magvar),
+      getFloat(wayPoint.geoidheight), getString(wayPoint.name), getString(wayPoint.cmt), getString(wayPoint.desc), getString(wayPoint.src),
+      wayPoint.link, getString(wayPoint.sym), getString(wayPoint.type), getString(wayPoint.fixType), getFloat(wayPoint.sat), getFloat(wayPoint.hdop),
+      getFloat(wayPoint.vdop), getFloat(wayPoint.pdop), getFloat(wayPoint.ageofdgpsdata), getInt(wayPoint.dgpsid));
       waypoints.push(point);
     });
 	}
@@ -70,6 +73,17 @@ var getFloat = function(item) {
 };
 
 /**
+ * Gets an integer from an element
+ **/
+var getInt = function(item) {
+  var value = null;
+  if (item && Array.isArray(item) && item.length > 0) {
+    value = parseInt(item[0]);
+  }
+  return value;
+};
+
+/**
  * Gets a string from an element
  **/
 var getString = function(item) {
@@ -88,22 +102,22 @@ var _getTracks = function(gpxTracks) {
 	var tracks = [];
 
   if (gpxTracks && gpxTracks.length) {
-  	
+
     gpxTracks.forEach(function(currentTrack) {
-  	
+
   		var trackSegments = [];
 
       currentTrack.trkseg.forEach(function(currentSegment) {
   			var trackSegement = [];
 
         currentSegment.trkpt.forEach(function(trackPoint) {
-  				var elevation = getFloat(trackPoint.ele);
-  				trackSegement.push(new GpxWaypoint(trackPoint.$.lat, trackPoint.$.lon, elevation, trackPoint.time));
+          trackSegement.push(new GpxWaypoint(trackPoint.$.lat, trackPoint.$.lon, getFloat(trackPoint.ele), trackPoint.time, getString(trackPoint.magvar),
+          getFloat(trackPoint.geoidheight), getString(trackPoint.name), getString(trackPoint.cmt), getString(trackPoint.desc), getString(trackPoint.src),
+          trackPoint.link, getString(trackPoint.sym), getString(trackPoint.type), getString(trackPoint.fixType), getFloat(trackPoint.sat), getFloat(trackPoint.hdop),
+          getFloat(trackPoint.vdop), getFloat(trackPoint.pdop), getFloat(trackPoint.ageofdgpsdata), getInt(trackPoint.dgpsid)));
   			});
-
   			trackSegments.push(trackSegement);
   		});
-
   		tracks.push(new GpxTrack(trackSegments, getString(currentTrack.name)));
   	});
   }
@@ -130,13 +144,12 @@ var _ParseV10 = function(gpx) {
  */
 var _ParseV11 = function(gpx) {
 	var metadata;
-  
+
 	if (gpx.metadata && gpx.metadata.length > 0) {
 		metadata = new GpxMetaData(gpx.$.creator, getString(gpx.metadata[0].time));
 	} else {
 		metadata = new GpxMetaData();
 	}
-
 	return new GpxResult(metadata, _getWayPoints(gpx.wpt), _getRoutes(gpx.rte), _getTracks(gpx.trk));
 };
 
@@ -161,7 +174,7 @@ exports.parseGpx = function(gpxString, callback) {
       if (!data.gpx) return callback(new Error("version not specified"), null);
 
     	version = data.gpx.$.version;
-    	
+
       switch (version) {
         case "1.0":
           gpxResult = _ParseV10(data.gpx);
@@ -174,7 +187,7 @@ exports.parseGpx = function(gpxString, callback) {
       }
 
       callback(null, gpxResult);
-   
+
     } catch (error) {
       return callback(error);
     }

--- a/lib/gpxWaypoint.js
+++ b/lib/gpxWaypoint.js
@@ -12,63 +12,41 @@
  * @param {string} cmt A comment regarding the waypoint.
  * @param {string} desc A description of the waypoint.
  * @param {string} src The source of the waypoint.
- * @param {string[]} links An array of links for the waypoint.
+ * @param {linkType[]} links An array of links for the waypoint.
  * @param {string} sym The symbol of the waypoint.
  * @param {string} type The type of waypoint.
+ * @param {string} fixType Type of fix to measure the waypoint, from list: {'none'|'2d'|'3d'|'dgps'|'pps'}
+ * @param {number} sat Number of satellites used to calculate the waypoint fix.
+ * @param {number} hdop Horizontal dilution of precision.
+ * @param {number} vdop Vertical dilution of precision.
+ * @param {number} pdop Position dilution of precision.
+ * @param {number} ageofdgpsdata Number of seconds since last DGPS update.
+ * @param {number} dgpsid ID of DGPS station used in differential correction.
  **/
-function GpxWaypoint(lat, lon, elevation, time, magvar, geoidheight, name, cmt, desc, src, links, sym, type) {
+function GpxWaypoint(lat, lon, elevation, time, magvar, geoidheight, name, cmt, desc, src, link, sym, type, fixType, sat, hdop, vdop, pdop, ageofdgpsdata, dgpsid) {
+	// if (elevation===4.94) {console.log(
+	// 	lat, lon, elevation, time, magvar, geoidheight, name, cmt, desc, src, link, sym, type, fixType, sat, hdop, vdop, pdop, ageofdgpsdata, dgpsid
+	// );}
 	lat = parseFloat(lat) || -1;
 	lon = parseFloat(lon) || -1;
 	elevation = elevation || -1;
 	time =  time ? new Date(time) : null;
+	magvar = parseFloat(magvar) || -1;
+	geoidheight = parseFloat(geoidheight) || -1;
 	name = name || null;
 	cmt = cmt || "";
 	desc = desc || null;
 	src = src || "";
+	link = link || [];
+	sym = sym || "";
 	type = type || "";
-
-	/**
-	 * Name of the Waypoint
-	 * @name name
-	 * @memberOf GpxWaypoint
-	 * @instance
-	 * @type {string}
-	**/
-	this.__defineGetter__("name", function() {
-		return name;
-	});
-
-
-	/**
-	* cmt of the Waypoint
-	* @name cmt
-	* @memberOf GpxWaypoint
-	* @instance
-	* @type {string}
-	**/
-	this.__defineGetter__("cmt", function() {
-		return cmt;
-	});
-
-	/**
-	* Description of the Waypoint
-	* @name description
-	* @memberOf GpxWaypoint
-	* @instance
-	* @type {string}
-	**/
-	Object.defineProperty(this,'description', {
-  	get: function() { return desc; }
-  });
-
-	this.__defineGetter__("src", function() {
-		return src;
-	});
-
-	this.__defineGetter__("type", function() {
-		return type;
-	});
-
+	fixType = fixType || null;
+	sat = sat || -1
+	hdop = parseFloat(hdop) || -1;
+	vdop = parseFloat(vdop) || -1;
+	pdop = parseFloat(pdop) || -1;
+	ageofdgpsdata = parseFloat(ageofdgpsdata) || -1;
+	dgpsid = dgpsid || -1;
 	/**
 	* Latitude of the Waypoint
 	* @name lat
@@ -91,7 +69,6 @@ function GpxWaypoint(lat, lon, elevation, time, magvar, geoidheight, name, cmt, 
 		return lon;
 	});
 
-
 	/**
 	* Elevation at the Waypoint
 	* @name elevation
@@ -103,7 +80,6 @@ function GpxWaypoint(lat, lon, elevation, time, magvar, geoidheight, name, cmt, 
 		return elevation;
 	});
 
-
 	/**
 	* Time associated with the Waypoint
 	* @name time
@@ -113,6 +89,191 @@ function GpxWaypoint(lat, lon, elevation, time, magvar, geoidheight, name, cmt, 
 	**/
 	this.__defineGetter__("time", function() {
 		return time;
+	});
+
+	/**
+	* Magnetic variation at the Waypoint.
+	* @name magvar
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("magvar", function() {
+		return magvar;
+	});
+
+	/**
+	* Geoid height at the Waypoint.
+	* @name geoidheight
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("geoidheight", function() {
+		return geoidheight;
+	});
+
+	/**
+	 * Name of the Waypoint
+	 * @name name
+	 * @memberOf GpxWaypoint
+	 * @instance
+	 * @type {string}
+	**/
+	this.__defineGetter__("name", function() {
+		return name;
+	});
+
+	/**
+	* Comment on the Waypoint
+	* @name cmt
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("cmt", function() {
+		return cmt;
+	});
+
+	/**
+	* Description of the Waypoint
+	* @name desc
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("description", function() {
+		return desc;
+	});
+
+	/**
+	* Source of the the Waypoint
+	* @name src
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("src", function() {
+		return src;
+	});
+
+	/**
+	* Links associated with the Waypoint
+	* @name link
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {Array<linkType>}
+	**/
+
+	this.__defineGetter__("links", function() {
+		if (link.length) {
+			return link.map(function(l) {
+				var href = l.hasOwnProperty('$') ? l.$.href : "";
+				var text = l.text&&l.text[0] ? l.text[0] : "";
+				var type = l.type&&l.type[0] ? l.type[0] : "";
+				return {href:href, text:text, type:type};
+			});
+		}
+		else { return []; }
+	});
+
+	/**
+	* Symbol used to mark the Waypoint
+	* @name sym
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("sym", function() {
+		return sym;
+	});
+
+	/**
+	* Type associated with the Waypoint
+	* @name type
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("type", function() {
+		return type;
+	});
+
+	/**
+	* Fix tyoe used measure the waypoint, from list: {'none'|'2d'|'3d'|'dgps'|'pps'}
+	* @name fixType
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {string}
+	**/
+	this.__defineGetter__("fixType", function() {
+		return fixType;
+	});
+
+	/**
+	* Number of satellites used to calculate the waypoint fix.
+	* @name sat
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("sat", function() {
+		return sat;
+	});
+
+	/**
+	* Horizontal dilution of precision.
+	* @name hdop
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("hdop", function() {
+		return hdop;
+	});
+
+	/**
+	* Vertical dilution of precision.
+	* @name vdop
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("vdop", function() {
+		return vdop;
+	});
+
+	/**
+	* Position dilution of precision.
+	* @name pdop
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("pdop", function() {
+		return pdop;
+	});
+
+	/**
+	* Number of seconds since last DGPS update.
+	* @name ageofdgpsdata
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("ageofdgpsdata", function() {
+		return ageofdgpsdata;
+	});
+
+	/**
+	* ID of DGPS station used in differential correction.
+	* @name dgpsid
+	* @memberOf GpxWaypoint
+	* @instance
+	* @type {number}
+	**/
+	this.__defineGetter__("dgpsid", function() {
+		return dgpsid;
 	});
 }
 

--- a/tests/gpx-v1.0-tests.js
+++ b/tests/gpx-v1.0-tests.js
@@ -128,22 +128,51 @@ module.exports = {
         '<bounds minlat="42.401051" minlon="-71.126602" maxlat="42.468655" maxlon="-71.102973"/>',
         '<wpt lat="42.438878" lon="-71.119277">',
         '<ele>44.586548</ele>',
+        '<src>thesource</src>',
         '<time>2001-11-28T21:05:28Z</time>',
+        '<magvar>33.324</magvar>',
+        '<geoidheight>11.1</geoidheight>',
         '<name>5066</name>',
         '<desc><![CDATA[5066]]></desc>',
         '<sym>Crossing</sym>',
+        '<cmt>le comment</cmt>',
+        '<link href="google.com"><text>google</text><type>text\/html</type></link>',
+        '<link href="cnn.com"><text>cnn</text></link>',
         '<type><![CDATA[Crossing]]></type>',
+        '<type><![CDATA[Crossing]]></type>',
+        '<sat>4</sat>',
+        '<hdop>0.9</hdop>',
+        '<vdop>0.04</vdop>',
+        '<pdop>0.3210</pdop>',
+        '<ageofdgpsdata>744.6</ageofdgpsdata>',
+        '<dgpsid>13</dgpsid>',
         '</wpt>',
         '</gpx>'].join('');
 
         gpxParse.parseGpx(wayPointGpx, function(err, result) {
-            
             test.equal(err, null);
             test.equal(result.tracks.length, 0);
             test.equal(result.routes.length, 0);
             test.equal(result.waypoints.length, 1);
             test.equal(result.waypoints[0].name, "5066");
+            test.equal(result.waypoints[0].links.length, 2);
+            test.equal(result.waypoints[0].links[0].href, "google.com");
+            test.equal(result.waypoints[0].links[0].text, "google");
+            test.equal(result.waypoints[0].links[0].type, "text/html");
+            test.equal(result.waypoints[0].links[1].href, "cnn.com");
+            test.equal(result.waypoints[0].links[1].type, "");
+            test.equal(result.waypoints[0].cmt, "le comment");
+            test.equal(result.waypoints[0].sym, "Crossing");
+            test.equal(result.waypoints[0].fixType, null);
+            test.equal(result.waypoints[0].sat, 4);
+            test.equal(result.waypoints[0].hdop, 0.9);
+            test.equal(result.waypoints[0].src, "thesource");
+            test.equal(result.waypoints[0].vdop, 0.04);
+            test.equal(result.waypoints[0].pdop, 0.3210);
+            test.equal(result.waypoints[0].ageofdgpsdata, 744.6);
+            test.equal(result.waypoints[0].dgpsid, 13);
+            test.equal(result.waypoints[0].description, "5066");
             test.done();
-        });        
+        });
     }
 };

--- a/tests/gpx-v1.1-tests.js
+++ b/tests/gpx-v1.1-tests.js
@@ -22,6 +22,23 @@ var gpxParse = require("../"),
     '</trkpt>',
     '<trkpt lat="47.644548" lon="-122.326897">',
     '<ele>4.94</ele>',
+    '<src>thesource</src>',
+    '<magvar>33.324</magvar>',
+    '<geoidheight>11.1</geoidheight>',
+    '<name>5066</name>',
+    '<desc><![CDATA[5066]]></desc>',
+    '<sym>Crossing</sym>',
+    '<cmt>le comment</cmt>',
+    '<link href="google.com"><text>google</text><type>text\/html</type></link>',
+    '<link href="cnn.com"><text>cnn</text></link>',
+    '<type><![CDATA[Crossing]]></type>',
+    '<type><![CDATA[Crossing]]></type>',
+    '<sat>4</sat>',
+    '<hdop>0.9</hdop>',
+    '<vdop>0.04</vdop>',
+    '<pdop>0.3210</pdop>',
+    '<ageofdgpsdata>744.6</ageofdgpsdata>',
+    '<dgpsid>13</dgpsid>',
     '<time>2009-10-17T18:37:31Z</time>',
     '</trkpt>',
     '<trkpt lat="47.644548" lon="-122.326897">',
@@ -56,6 +73,24 @@ module.exports = {
       test.equal(result.tracks[0].name, 'Example GPX Document');
       test.equal(result.tracks[0].segments[0][0].time, new Date('2009-10-17T18:37:26Z').toString());
       test.equal(result.tracks[0].segments[0][0].elevation, 4.46);
+      test.equal(result.tracks[0].segments[0][1].name, "5066");
+      test.equal(result.tracks[0].segments[0][1].links.length, 2);
+      test.equal(result.tracks[0].segments[0][1].links[0].href, "google.com");
+      test.equal(result.tracks[0].segments[0][1].links[0].text, "google");
+      test.equal(result.tracks[0].segments[0][1].links[0].type, "text/html");
+      test.equal(result.tracks[0].segments[0][1].links[1].href, "cnn.com");
+      test.equal(result.tracks[0].segments[0][1].links[1].type, "");
+      test.equal(result.tracks[0].segments[0][1].cmt, "le comment");
+      test.equal(result.tracks[0].segments[0][1].sym, "Crossing");
+      test.equal(result.tracks[0].segments[0][1].fixType, null);
+      test.equal(result.tracks[0].segments[0][1].sat, 4);
+      test.equal(result.tracks[0].segments[0][1].hdop, 0.9);
+      test.equal(result.tracks[0].segments[0][1].src, "thesource");
+      test.equal(result.tracks[0].segments[0][1].vdop, 0.04);
+      test.equal(result.tracks[0].segments[0][1].pdop, 0.3210);
+      test.equal(result.tracks[0].segments[0][1].ageofdgpsdata, 744.6);
+      test.equal(result.tracks[0].segments[0][1].dgpsid, 13);
+      test.equal(result.tracks[0].segments[0][1].description, "5066");
       test.done();
     });
 

--- a/tests/object-tests.js
+++ b/tests/object-tests.js
@@ -56,7 +56,7 @@ module.exports = {
     },
 
     "Test that the gpxWaypoint can be initialized": function(test) {
-        var gpxPoint = new GpxWaypoint(1, 2, 3, "2002-02-27T17:18:33Z",1,1,"name","cmt", "description");
+        var gpxPoint = new GpxWaypoint(1, 2, 3, "2002-02-27T17:18:33Z",1,1,"name","cmt","description","src",[{$:{href:'test.com'},text:['text'],type:['text/html']}], "sym", "type", "fixType", 4, 0.5, 0.4, 0.02, 35788.7, 13);
         test.equal(gpxPoint.lat, 1);
         test.equal(gpxPoint.lon, 2);
         test.equal(gpxPoint.elevation, 3);
@@ -64,6 +64,19 @@ module.exports = {
         test.equal(gpxPoint.name, "name");
         test.equal(gpxPoint.cmt, "cmt");
         test.equal(gpxPoint.description, "description");
+        test.equal(gpxPoint.src, "src");
+        test.equal(gpxPoint.links[0].href, "test.com");
+        test.equal(gpxPoint.links[0].text, "text");
+        test.equal(gpxPoint.links[0].type, "text/html");
+        test.equal(gpxPoint.sym, "sym");
+        test.equal(gpxPoint.type, "type");
+        test.equal(gpxPoint.fixType, "fixType");
+        test.equal(gpxPoint.sat, 4);
+        test.equal(gpxPoint.hdop, 0.5);
+        test.equal(gpxPoint.vdop, 0.4);
+        test.equal(gpxPoint.pdop, 0.02);
+        test.equal(gpxPoint.ageofdgpsdata, 35788.7);
+        test.equal(gpxPoint.dgpsid, 13);
         test.done();
     },
 


### PR DESCRIPTION
## things added+fixed
1. I added `cmt` to the Waypoint creation step in gpxParse so that a comment in the waypoint XML is associated with the new GpxWaypoint.
2. I added the missing Waypoint elements [per these docs](http://www.topografix.com/gpx/1/1/#type_wptType) and added support to the parser for V1.0 and V1.1 GPX parsing. I also added support for the `Links` field — please make sure it is implemented how you envision it. Now it returns an empty array `[]` if no links are present, else an array of objects with keys `src, text, type`. It allows for missing values for any of these fields, returning in this case an empty string `""`.
3. I added tests for v1.0, v1.1, and object-tests to cover the new code.

### oops
I squashed commits from the previous PR and filed a new one to clean things up, hence the slight duplication. Sorry about the git messiness.

closes #25 